### PR TITLE
Create CPU and GPU plots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Cython>=0.29.36
 pyslurm @ git+https://github.com/PySlurm/pyslurm.git@v24.11.0
 influxdb-client==1.37.0
 tabulate==0.9.0
+plotext==5.3.2
+numpy==2.3.2

--- a/src/influx.py
+++ b/src/influx.py
@@ -1,4 +1,5 @@
 import time
+import numpy as np
 from datetime import datetime
 from influxdb_client import InfluxDBClient
 
@@ -257,6 +258,45 @@ class InfluxQuery:
 
         return data
 
+    def get_avg_usage(self, job_id, measurement_type="cpu"):
+        """
+        Query InfluxDB for CPU or GPU usage statistics and calculate the average.
+
+        Args:
+            job_id: The job ID to query for
+            measurement_type (str): Type of measurement to get ("cpu" or "gpu")
+
+        Returns:
+            float: Average usage percentage, or None if no data found
+
+        Raises:
+            ValueError: If measurement_type is not "cpu" or "gpu"
+        """
+        if measurement_type == "cpu":
+            measurement = "average_cpu_usage"
+        elif measurement_type == "gpu":
+            measurement = "average_gpu_usage"
+        else:
+            raise ValueError(f"measurement_type must be 'cpu' or 'gpu', got '{measurement_type}'")
+
+        job_query = f"""
+        from(bucket: "{self.get_bucket()}")
+        |> range({self.search_window_str})
+        |> filter(fn: (r) => r["_measurement"] == "{measurement}")
+        |> filter(fn: (r) => r["job_id"] == "{job_id}")
+        |> mean()
+        """
+
+        job_results = self.query(job_query)
+
+        if len(job_results) > 0:
+            result = job_results[0].records[0].get_value()
+            if self.verbose:
+                print(f"(get_avg_usage) {measurement_type} result: ", result)
+            return result
+        else:
+            return None
+
     def get_avg_cpu(self, job_id):
         """
         Query InfluxDB for CPU usage statistics and calculate the average.
@@ -267,24 +307,7 @@ class InfluxQuery:
         Returns:
             float: Average CPU usage percentage, or None if no data found
         """
-
-        job_query = f"""
-        from(bucket: "{self.get_bucket()}")
-        |> range({self.search_window_str})
-        |> filter(fn: (r) => r["_measurement"] == "average_cpu_usage")
-        |> filter(fn: (r) => r["job_id"] == "{job_id}")
-        |> mean()
-        """
-
-        job_results = self.query(job_query)
-
-        if len(job_results) > 0:
-            result = job_results[0].records[0].get_value()
-            if self.verbose:
-                print("(get_avg_cpu) result: ", result)
-            return result
-        else:
-            return None
+        return self.get_avg_usage(job_id, "cpu")
 
     def get_avg_gpu(self, job_id):
         """
@@ -296,21 +319,86 @@ class InfluxQuery:
         Returns:
             float: Average GPU usage percentage, or None if no data found
         """
+        return self.get_avg_usage(job_id, "gpu")
+
+    def get_usage_series(self, job_id, measurement_type="cpu"):
+        """
+        Query InfluxDB for CPU or GPU usage time series data.
+
+        Args:
+            job_id: The job ID to query for
+            measurement_type (str): Type of measurement to get ("cpu" or "gpu")
+
+        Returns:
+            dict: Dictionary containing 'time' (timestamps as int64) and 'value' (usage as float64) numpy arrays,
+                  or None if no data found
+
+        Raises:
+            ValueError: If measurement_type is not "cpu" or "gpu"
+        """
+        if measurement_type == "cpu":
+            measurement = "average_cpu_usage"
+        elif measurement_type == "gpu":
+            measurement = "average_gpu_usage"
+        else:
+            raise ValueError(f"measurement_type must be 'cpu' or 'gpu', got '{measurement_type}'")
 
         job_query = f"""
         from(bucket: "{self.get_bucket()}")
         |> range({self.search_window_str})
-        |> filter(fn: (r) => r["_measurement"] == "average_gpu_usage")
+        |> filter(fn: (r) => r["_measurement"] == "{measurement}")
         |> filter(fn: (r) => r["job_id"] == "{job_id}")
-        |> mean()
+        |> filter(fn: (r) => r["_field"] == "value")
+        |> keep(columns: ["_time", "_value"])
         """
 
         job_results = self.query(job_query)
 
         if len(job_results) > 0:
-            result = job_results[0].records[0].get_value()
+            # Count total records first
+            total_records = sum(len(table.records) for table in job_results)
+
+            # Pre-allocate numpy arrays with appropriate dtypes
+            timestamps = np.empty(total_records, dtype=np.int64)
+            values = np.empty(total_records, dtype=np.float64)
+
+            i = 0
+            for table in job_results:
+                for record in table.records:
+                    timestamps[i] = int(record.get_time().timestamp())
+                    values[i] = record.get_value()
+                    i += 1
+
+            result = {"time": timestamps, "value": values}
             if self.verbose:
-                print("(get_avg_gpu) result: ", result)
+                print(f"(get_usage_series) {measurement_type} result:")
+                print(result)
             return result
         else:
             return None
+
+    def get_cpu_series(self, job_id):
+        """
+        Query InfluxDB for CPU usage time series data.
+
+        Args:
+            job_id: The job ID to query for
+
+        Returns:
+            dict: Dictionary containing 'time' (timestamps as int64) and 'value' (CPU usage as float64) numpy arrays,
+                  or None if no data found
+        """
+        return self.get_usage_series(job_id, "cpu")
+
+    def get_gpu_series(self, job_id):
+        """
+        Query InfluxDB for GPU usage time series data.
+
+        Args:
+            job_id: The job ID to query for
+
+        Returns:
+            dict: Dictionary containing 'time' (timestamps as int64) and 'value' (GPU usage as float64) numpy arrays,
+                  or None if no data found
+        """
+        return self.get_usage_series(job_id, "gpu")

--- a/src/jobreport.py
+++ b/src/jobreport.py
@@ -10,13 +10,13 @@ from report import JobReport
 from influx import InfluxQuery
 
 
-def get_report(job_id, influx_config=None, debug=False):
+def get_report(job_id, influx_config=None, debug=False, plot=False):
     query = None
 
     # Initialize InfluxQuery if the configuration file exists
     if influx_config is not None and Path(influx_config).exists():
         try:
-            query = InfluxQuery(Path(influx_config), retries=3)
+            query = InfluxQuery(Path(influx_config), retries=3, verbose=debug)
         except Exception:
             print_stderr("Warning: InfluxQuery could not be initialized")
             if debug:
@@ -24,11 +24,11 @@ def get_report(job_id, influx_config=None, debug=False):
     else:
         print_stderr("Warning: InfluxDB configuration file not found")
 
-    job_report = JobReport(job_id, query)
+    job_report = JobReport(job_id, query, plot)
     return job_report
 
 
-def main(job_id, epilog=False, influx_config=None, debug=False):
+def main(job_id, epilog=False, influx_config=None, debug=False, plot=False):
     raw_id = JobReport.get_raw_id(job_id)
     stdout_file = None
     batch_host = None
@@ -60,7 +60,7 @@ def main(job_id, epilog=False, influx_config=None, debug=False):
         return
 
     # Create job report
-    job_report = get_report(job_id, influx_config, debug)
+    job_report = get_report(job_id, influx_config, debug, plot)
 
     # Do nothing if in epilog mode and the job hasn't finished
     if epilog and not job_report.finished:
@@ -118,6 +118,17 @@ if __name__ == "__main__":
         type=str,
         help="InfluxDB configuration file",
     )
+    parser.add_argument(
+        "-p",
+        "--plot",
+        "--plot-width",
+        nargs="?",
+        type=int,
+        const=True,
+        default=False,
+        help="Generate plots for the job report (optionally specify a plot width)",
+    )
+
     args = parser.parse_args()
 
     # for nicer output in slurmd logs
@@ -128,7 +139,7 @@ if __name__ == "__main__":
     try:
         # Ensure the code does not hang
         with Timeout(int(args.timeout)):
-            main(args.job_id, args.epilog, args.influx_config, args.debug)
+            main(args.job_id, args.epilog, args.influx_config, args.debug, args.plot)
 
     # Print exception tracebacks if in debug mode
     except Exception:

--- a/src/report.py
+++ b/src/report.py
@@ -1,7 +1,10 @@
+import shutil
 import pyslurm
+import numpy as np
+import plotext
 
 from tabulate import tabulate
-from utils import humansize, seconds_to_str, percentage_bar
+from utils import humansize, seconds_to_str, percentage_bar, resample, pretty_time
 
 
 UNFINISHED_STATES = ["PENDING", "RUNNING", "REQUEUED", "RESIZING", "SUSPENDED"]
@@ -9,7 +12,7 @@ UNFINISHED_STATES = ["PENDING", "RUNNING", "REQUEUED", "RESIZING", "SUSPENDED"]
 
 class JobReport:
 
-    def __init__(self, job_id, influxquery=None):
+    def __init__(self, job_id, influxquery=None, plot=False):
         self.job_id = job_id
         self.raw_id = self.get_raw_id(str(job_id))
         self.db_data = pyslurm.db.Job.load(self.raw_id)
@@ -48,7 +51,26 @@ class JobReport:
         self.warnings = self.get_warnings()
         self.report_data["warnings"] = self.warnings
 
+        if plot and self.influxquery is not None:
+            self.plot_data = {}
+            dataseries = self.influxquery.get_cpu_series(self.influxid)
+            if dataseries is not None:
+                self.plot_data["cpu"] = dataseries
+            dataseries = self.influxquery.get_gpu_series(self.influxid)
+            if dataseries is not None:
+                self.plot_data["gpu"] = dataseries
+        else:
+            self.plot_data = None
+
         self.heading_width = 14
+
+        if plot and type(plot) is int:
+            self.plot_width = plot
+            self.plot_height = 0.3 * self.plot_width
+        else:
+            terminal_size = shutil.get_terminal_size(fallback=(73/0.8, 22/0.8))
+            self.plot_width = 0.8 * terminal_size.columns
+            self.plot_height = 0.8 * terminal_size.lines
 
     def __str__(self):
         return self.get_full_report()
@@ -193,6 +215,31 @@ class JobReport:
                 warnings += ["Too much time requested"]
 
         return warnings
+
+    def generate_plots(self):
+
+        plots = {}
+
+        if self.plot_data is None:
+            return plots
+
+        for key, series in self.plot_data.items():
+            if series is not None:
+                x, tunit = pretty_time(series['time'])
+                y = series['value']
+                x = resample(x, self.plot_width*2)
+                y = resample(y, self.plot_width*2)
+
+                plotext.clear_figure()
+                plotext.ylim(0,100)
+                plotext.plotsize(self.plot_width, self.plot_height)
+                plotext.plot(x, y, color='black')
+                plotext.theme('clear')
+                plotext.title(f"[ % {key.upper()} USAGE ]")
+                plotext.xlabel(f'Time ({tunit})')
+                plots[key] = plotext.build()
+
+        return plots
 
     @staticmethod
     def get_raw_id(job_id):
@@ -404,5 +451,10 @@ class JobReport:
             + [f"| {line.ljust(max_len)} |" for line in lines]
             + [bottom_border]
         )
+
+        if self.plot_data is not None:
+            linebreak = '\n\n'
+            report += linebreak
+            report += linebreak.join(self.generate_plots().values())
 
         return report

--- a/src/report.py
+++ b/src/report.py
@@ -227,6 +227,8 @@ class JobReport:
             if series is not None:
                 x, tunit = pretty_time(series['time'])
                 y = series['value']
+                # Resample to 2x the plot width, since the ascii characters used for plotting
+                # can represent roughly two points each
                 x = resample(x, self.plot_width*2)
                 y = resample(y, self.plot_width*2)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,8 @@ import pyslurm
 import traceback
 import sys
 
+import numpy as np
+
 
 def print_stderr(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -72,3 +74,65 @@ class Timeout:
 
     def __exit__(self, type, value, traceback):
         signal.alarm(0)
+
+
+def resample(y, n_points):
+    """
+    Resamples a 1D array to a new number of points using linear interpolation.
+
+    Args:
+        y (array-like): The input 1D array of data.
+        n_points (int): The desired number of points in the output array.
+
+    Returns:
+        np.ndarray: The resampled array.
+    """
+    y = np.asarray(y)
+    assert y.ndim == 1, "Input array must be one-dimensional."
+
+    norig = len(y)
+    npoints = int(n_points)
+
+    # Need at least 2 points
+    assert norig > 1, "Original array must have more than 1 point."
+    assert npoints > 1, "n_points must be greater than 1."
+
+    if npoints != norig:
+        # Create the x-coordinates for the original and new arrays
+        x_old = np.linspace(0, 1, norig)
+        x_new = np.linspace(0, 1, npoints)
+        return np.interp(x_new, x_old, y)
+    else:
+        # If the number of points is the same, return a copy
+        return y.copy()
+
+
+def pretty_time(t):
+    """
+    Convert timestamps to relative time with appropriate units (sec, mins, hrs, days).
+
+    Args:
+        t (array-like): Array of timestamps in seconds
+
+    Returns:
+        tuple: (relative_time_array, unit_string)
+    """
+    minute = 60
+    hour = 60*minute
+    day = 24*hour
+    x = t - t[0]
+    tunit = "sec"
+
+    assert x[-1] >= 0
+
+    if x[-1] > 2*day:
+        x = x / day
+        tunit = "days"
+    elif x[-1] > 2*hour:
+        x = x / hour
+        tunit = "hrs"
+    elif x[-1] > 2*minute:
+        x = x / minute
+        tunit = "mins"
+
+    return x, tunit


### PR DESCRIPTION
This pull request adds support for generating CPU and GPU usage plots in job reports by fetching time series data from InfluxDB and rendering terminal plots. It introduces new methods for querying and processing usage data, updates the command-line interface to allow plot generation, and adds utility functions for resampling and formatting time series data.

**InfluxDB querying and data processing:**

* Refactored and generalized the InfluxDB querying logic in `src/influx.py` to support both CPU and GPU usage statistics, including new methods `get_avg_usage`, `get_usage_series`, `get_cpu_series`, and `get_gpu_series`, which return time series data as numpy arrays. [[1]](diffhunk://#diff-a7ec56437cf73e4c0341ee8430eed637c33bf327340279f562cf7a2e051ece44L260-R285) [[2]](diffhunk://#diff-a7ec56437cf73e4c0341ee8430eed637c33bf327340279f562cf7a2e051ece44L284-R311) [[3]](diffhunk://#diff-a7ec56437cf73e4c0341ee8430eed637c33bf327340279f562cf7a2e051ece44R322-R404)
* Added numpy as a dependency for efficient array handling and time series processing in `src/influx.py` and `src/utils.py`. [[1]](diffhunk://#diff-a7ec56437cf73e4c0341ee8430eed637c33bf327340279f562cf7a2e051ece44R2) [[2]](diffhunk://#diff-51246e53255db77c9edad496f074aa1bdbf8dbdc11f89a02040115c9ab4fa7f0R6-R7)

**Job report enhancements and plotting:**

* Modified `JobReport` in `src/report.py` to fetch and store usage time series data, and added logic to generate terminal plots using `plotext` for CPU and GPU usage. The plot dimensions adapt to terminal size or can be specified by the user. [[1]](diffhunk://#diff-71eacd2a817bffc7685970c6d8eb9393feda238584a87185db0aac613eadabe8R1-R15) [[2]](diffhunk://#diff-71eacd2a817bffc7685970c6d8eb9393feda238584a87185db0aac613eadabe8R54-R74) [[3]](diffhunk://#diff-71eacd2a817bffc7685970c6d8eb9393feda238584a87185db0aac613eadabe8R219-R243) [[4]](diffhunk://#diff-71eacd2a817bffc7685970c6d8eb9393feda238584a87185db0aac613eadabe8R455-R459)

**Command-line interface improvements:**

* Updated `src/jobreport.py` to add a new `--plot` (`-p`) argument, allowing users to generate plots in job reports and optionally specify plot width. The plotting option is propagated through the report generation workflow. [[1]](diffhunk://#diff-f947b89023a39e355eab59c582aa4711ee6caccf3ca218181394522c9832b98aL13-R31) [[2]](diffhunk://#diff-f947b89023a39e355eab59c582aa4711ee6caccf3ca218181394522c9832b98aL63-R63) [[3]](diffhunk://#diff-f947b89023a39e355eab59c582aa4711ee6caccf3ca218181394522c9832b98aR121-R131) [[4]](diffhunk://#diff-f947b89023a39e355eab59c582aa4711ee6caccf3ca218181394522c9832b98aL131-R142)

**Utility functions for time series data:**

* Added `resample` for linear interpolation of arrays and `pretty_time` for formatting timestamps with appropriate units to `src/utils.py`, supporting plot rendering and time axis labeling.